### PR TITLE
Fix for 'No input file specified.' error when running PHP as FastCGI

### DIFF
--- a/web/.htaccess
+++ b/web/.htaccess
@@ -16,5 +16,5 @@
     RewriteCond %{REQUEST_FILENAME} !-d
     RewriteCond %{REQUEST_FILENAME} !-f
     RewriteCond %{REQUEST_FILENAME} !favicon.ico$
-    RewriteRule ^(.*)$ index.php/$1 [QSA,L]
+    RewriteRule ^(.*)$ index.php [QSA,L]
 </IfModule>


### PR DESCRIPTION
I had to make this change to get aura running with FastCGI. This works fine with mod_php as well.
