### PR TITLE
Remove name from composer.json and add aura/composer as the required one...

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,20 +1,19 @@
 {
-    "name": "aura/system",
     "minimum-stability": "dev",
     "require": {
-        "composer/installers"   : "*",
-        "aura/autoload"         : "dev-develop",
-        "aura/cli"              : "dev-develop",
-        "aura/di"               : "dev-develop",
-        "aura/http"             : "dev-develop",
-        "aura/framework"        : "dev-develop",
-        "aura/filter"           : "dev-develop",
-        "aura/marshal"          : "dev-develop",
-        "aura/router"           : "dev-develop",
-        "aura/signal"           : "dev-develop",
-        "aura/sql"              : "dev-develop",
-        "aura/uri"              : "dev-develop",
-        "aura/view"             : "dev-develop",
-        "aura/web"              : "dev-develop"
+        "aura/composer"   : "*",
+        "aura/autoload"   : "dev-develop",
+        "aura/cli"        : "dev-develop",
+        "aura/di"         : "dev-develop",
+        "aura/http"       : "dev-develop",
+        "aura/framework"  : "dev-develop",
+        "aura/filter"     : "dev-develop",
+        "aura/marshal"    : "dev-develop",
+        "aura/router"     : "dev-develop",
+        "aura/signal"     : "dev-develop",
+        "aura/sql"        : "dev-develop",
+        "aura/uri"        : "dev-develop",
+        "aura/view"       : "dev-develop",
+        "aura/web"        : "dev-develop"
     }
 }


### PR DESCRIPTION
.... I hope this will try to download the aura/composer first then only the remaining ones. Still wondering .

This PR works once the PR of composer/installer being removed.

https://github.com/composer/installers/pull/27
