### PR TITLE
Fix "Try it out" section in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ $di->params['Aura\Router\Map']['attach'][''] = [
 // map the 'home' controller value to the controller class
 $di->params['Aura\Framework\Web\Controller\Factory']['map']['home'] = 'Example\Package\Web\Home\HomePage';
 ?>
+```
 
 ### Try It Out
 


### PR DESCRIPTION
Added ``` after the last php code block so that the "Try It Out" section is displayed properly instead of being shown as part of the code block.
